### PR TITLE
Add a package.json file for npm support

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,10 +1,24 @@
 {
+  "name": "upbase",
+  "main": "scss/_upbase.scss",
+  "description": "Bespoke Sass mixin library from Upstatement",
   "homepage": "http://upbase.upstatement.com/",
+  "url" : "https://github.com/Upstatement/upbase/issues",
+  "repository" : {
+    "type" : "git",
+    "url" : "https://github.com/upstatement/upbase.git"
+  },
+  "email" : "info@upstatement.com",
   "license": {
     "type": "MIT",
-    "url": "https://github.com/Upstatement/upbase"
+    "url": "https://github.com/Upstatement/upbase/blob/master/LICENSE.md"
   },
-  "name": "upbase",
   "private": true,
-  "version": "0.0.0"
+  "version": "1.0.0",
+  "keywords": [
+    "css",
+    "sass",
+    "scss",
+    "mixins"
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,10 @@
+{
+  "homepage": "http://upbase.upstatement.com/",
+  "license": {
+    "type": "MIT",
+    "url": "https://github.com/Upstatement/upbase"
+  },
+  "name": "upbase",
+  "private": true,
+  "version": "0.0.0"
+}


### PR DESCRIPTION
I wanted to use a single package manager, NPM, instead of both NPM and Bower, in an update to my boilerplate project [jvlahos/jeffman](https://www.github.com/jvlahos/jeffman)... seemed redundant to be using both. However, when I tried to `npm install` Upbase Neue using a branch-suffixed GitHub URL, I received an error due to there being no `package.json` file in Upbase.

So, I created a fork of Upbase, published a `package.json` file to my fork, and then tried with my forked version — worked. If ya'll decide to support that, feel free to take it and merge it on into Andy's branch.
